### PR TITLE
How to specify the `node` location

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,37 @@ type can optionally produce managed resources.
 The other types of plugin are ones that wish to just invoke the js engine and so there are helper functions to do
 that.
 
-sbt-js-engine also enhances sbt-web with [npm](https://www.npmjs.org/) functionality. If a `package.json` file
-is found in the project's base directory then it will cause npm to run. By default npm will run in the JVM but just
-as with other sbt-js-engine plugins, the type of engine can be configured. For example to use Node directly:
+The following options are provided:
+
+Option              | Description
+--------------------|------------
+command             | The filesystem location of the command to execute. Commands such as "node" default to being known to your path. However there path can be supplied here."
+engineType          | The type of engine to use i.e. CommonNode, Node, PhantomJs, Rhino or Trireme. The default is Trireme.
+parallelism         | The number of parallel tasks for the JavaScript engine. Defaults to the # of available processors + 1 to keep things busy.
+npmTimeout          | The maximum number of seconds to for npm to do its thing.
+
+The following sbt code illustrates how the engine type can be set to Node:
 
 ```scala
 JsEngineKeys.engineType := JsEngineKeys.EngineType.Node
 ```
 
-Alternatively you can provide a system property via SBT_OPTS, for example:
+Alternatively, for `command` and `engineType` you can provide a system property via SBT_OPTS, for example:
 
 ```bash
 export SBT_OPTS="$SBT_OPTS -Dsbt.jse.engineType=Node"
 ```
+
+and another example:
+
+```bash
+export SBT_OPTS="$SBT_OPTS -Dsbt.jse.command=/usr/local/bin/node"
+```
+
+## npm
+
+sbt-js-engine also enhances sbt-web with [npm](https://www.npmjs.org/) functionality. If a `package.json` file
+is found in the project's base directory then it will cause npm to run.
 
 npm extracts its artifacts into the node_modules folder of a base directory and makes the contents available to
 sbt-web plugins as a whole. Note that sbt-js-engines loads the

--- a/sbt-js-engine-tester/build.sbt
+++ b/sbt-js-engine-tester/build.sbt
@@ -1,1 +1,2 @@
 lazy val root = (project in file(".")).addPlugins(SbtWeb)
+


### PR DESCRIPTION
I am trying to build my project on Heroku, using heroku-buildpack-multi to run both the node buildpack, and the sbt one.  They both seem to be running, but since the node buildpack downloads the node binary to a non-standard location, it seems that `sbt-rjs` (which uses `sbt-js-engine` for the actual processing, as best I can tell) cannot find `node`:

```
       [ERROR] [04/25/2014 04:44:18.777] [sbt-web-akka.actor.default-dispatcher-2] [akka://sbt-web/user/$a/process] null
       akka.actor.ActorInitializationException: exception during creation
        at akka.actor.ActorInitializationException$.apply(Actor.scala:218)
        at akka.actor.ActorCell.create(ActorCell.scala:578)
        at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:425)
        at akka.actor.ActorCell.systemInvoke(ActorCell.scala:447)
        at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:262)
        at akka.dispatch.Mailbox.run(Mailbox.scala:218)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1146)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:679)
       Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:532)
        at akka.util.Reflect$.instantiate(Reflect.scala:65)
        at akka.actor.Props.newActor(Props.scala:337)
        at akka.actor.ActorCell.newActor(ActorCell.scala:534)
        at akka.actor.ActorCell.create(ActorCell.scala:560)
        ... 7 more
       Caused by: java.io.IOException: Cannot run program "node": java.io.IOException: error=2, No such file or directory
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:475)
        at akka.contrib.process.BlockingProcess.<init>(BlockingProcess.scala:30)
        ... 15 more
       Caused by: java.io.IOException: java.io.IOException: error=2, No such file or directory
        at java.lang.UNIXProcess.<init>(UNIXProcess.java:164)
        at java.lang.ProcessImpl.start(ProcessImpl.java:81)
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:468)
        ... 16 more
```

Can I tell `sbt-js-engine` where to find node?

Thanks!
