### PR TITLE
Widen unmanagedSources scope for a task

### DIFF
--- a/src/main/scala/com/typesafe/sbt/jse/SbtJsTask.scala
+++ b/src/main/scala/com/typesafe/sbt/jse/SbtJsTask.scala
@@ -268,7 +268,7 @@ object SbtJsTask extends AutoPlugin {
       LocalEngine.nodePathEnv(nodeModulePaths.to[immutable.Seq])
     )
 
-    val sources = ((unmanagedSources in config).value ** ((includeFilter in task in config).value -- (excludeFilter in task in config).value)).get
+    val sources = ((unmanagedSources in task in config).value ** ((includeFilter in task in config).value -- (excludeFilter in task in config).value)).get
 
     val logger: Logger = state.value.log
 


### PR DESCRIPTION
In order that plugins can add or construct their own inputs, `unmanagedSources in config` should be expanded to `unmanagedSources in task in config`.
