### PR TITLE
Refine managed sources for source file tasks

### DIFF
--- a/src/main/scala/com/typesafe/sbt/jse/SbtJsTask.scala
+++ b/src/main/scala/com/typesafe/sbt/jse/SbtJsTask.scala
@@ -348,8 +348,8 @@ object SbtJsTask extends AutoPlugin {
       resourceGenerators <+= sourceFileTask,
       managedResourceDirectories += (resourceManaged in sourceFileTask).value
     ) ++ inTask(sourceFileTask)(Seq(
-      managedSourceDirectories <<= Def.settingDyn { sourceDependencies.value.map(resourceManaged in _).join },
-      managedSources <<= Def.taskDyn { sourceDependencies.value.join.map(_.flatten) },
+      managedSourceDirectories ++= Def.settingDyn { sourceDependencies.value.map(resourceManaged in _).join }.value,
+      managedSources ++= Def.taskDyn { sourceDependencies.value.join.map(_.flatten) }.value,
       sourceDirectories := unmanagedSourceDirectories.value ++ managedSourceDirectories.value,
       sources := unmanagedSources.value ++ managedSources.value
     ))


### PR DESCRIPTION
Append to rather than replace managedSourceDirectories and managedSources.

Allows `sourceGenerators in Assets` to be used (along with an earlier change that included managedSources as sources).
