### PR TITLE
Make this plugin work with sbt subprojects

### DIFF
--- a/src/main/scala/com/typesafe/sbt/jse/SbtJsEngine.scala
+++ b/src/main/scala/com/typesafe/sbt/jse/SbtJsEngine.scala
@@ -80,7 +80,7 @@ object SbtJsEngine extends AutoPlugin {
                 val npm = new Npm(engine, (webJarsNodeModulesDirectory in Plugin).value / "npm" / "lib" / "npm.js")
                 import ExecutionContext.Implicits.global
                 for (
-                  result <- npm.update()
+                  result <- npm.update(false, Seq("--prefix", baseDirectory.value.toString()))
                 ) yield {
                   // TODO: We need to stream the output and error channels. The js engine needs to change in this regard so that the
                   // stdio sink and sources can be exposed through the NPM library and then adopted here.


### PR DESCRIPTION
Make this plugin work with sbt subprojects, where package.json is in the subproject directory. In that case, we should explicitly pass the --prefix param to npm with the subproject's directory.

The directory structure would be like this:

```
root/
    build.sbt (root)
    project/
        plugins.sbt (containing sbt-js-engine)
    subproject/
        build.sbt (subproject)
        package.json (packages that subproject requires)
        node_modules/ (js modules that subproject can access)
```
