### PR TITLE
Make NPM work in sub modules

### DIFF
--- a/src/main/scala/com/typesafe/sbt/jse/SbtJsEngine.scala
+++ b/src/main/scala/com/typesafe/sbt/jse/SbtJsEngine.scala
@@ -80,7 +80,7 @@ object SbtJsEngine extends AutoPlugin {
                 val npm = new Npm(engine, (webJarsNodeModulesDirectory in Plugin).value / "npm" / "lib" / "npm.js")
                 import ExecutionContext.Implicits.global
                 for (
-                  result <- npm.update()
+                  result <- npm.update(global = false, Seq("--prefix", baseDirectory.value.getPath))
                 ) yield {
                   // TODO: We need to stream the output and error channels. The js engine needs to change in this regard so that the
                   // stdio sink and sources can be exposed through the NPM library and then adopted here.

--- a/src/sbt-test/sbt-js-engine/npmsubmodule/build.sbt
+++ b/src/sbt-test/sbt-js-engine/npmsubmodule/build.sbt
@@ -1,0 +1,9 @@
+name := """sbt-web-sub-module-npm"""
+
+version := "1.0-SNAPSHOT"
+
+lazy val subproject = (project in file("./subproject")).enablePlugins(SbtWeb)
+
+lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+
+scalaVersion := "2.11.1"

--- a/src/sbt-test/sbt-js-engine/npmsubmodule/package.json
+++ b/src/sbt-test/sbt-js-engine/npmsubmodule/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "stuff",
+  "devDependencies": {
+    "glob": "~4.0.6"
+  }
+}

--- a/src/sbt-test/sbt-js-engine/npmsubmodule/project/build.properties
+++ b/src/sbt-test/sbt-js-engine/npmsubmodule/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.5

--- a/src/sbt-test/sbt-js-engine/npmsubmodule/project/plugins.sbt
+++ b/src/sbt-test/sbt-js-engine/npmsubmodule/project/plugins.sbt
@@ -1,0 +1,7 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-js-engine" % sys.props("project.version"))
+
+resolvers ++= Seq(
+  Resolver.url("sbt snapshot plugins", url("http://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots"))(Resolver.ivyStylePatterns),
+  Resolver.sonatypeRepo("snapshots"),
+  "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
+)

--- a/src/sbt-test/sbt-js-engine/npmsubmodule/subproject/package.json
+++ b/src/sbt-test/sbt-js-engine/npmsubmodule/subproject/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "subproject-stuff",
+  "devDependencies": {
+    "mkdirp": "~0.5.0"
+  }
+}

--- a/src/sbt-test/sbt-js-engine/npmsubmodule/test
+++ b/src/sbt-test/sbt-js-engine/npmsubmodule/test
@@ -1,0 +1,10 @@
+# There should be no node modules as there is no package.json visible.
+> web-assets:webNodeModules
+$ exists node_modules/glob
+-$ exists subproject/node_modules/mkdirp
+
+> subproject/web-assets:webNodeModules
+$ exists node_modules/glob
+-$ exists node_modules/mkdirp
+$ exists subproject/node_modules/mkdirp
+-$ exists subproject/node_modules/glob


### PR DESCRIPTION
@tfeng wrote a fix for executing npm correctly for sub modules (#16).

This extends that pull request by a test which can be run via "sbt scripted".

If you revert his patch 705bab8, the test fails.
