### PR TITLE
Make shell source extraction a build setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,5 +12,5 @@ libraryDependencies ++= Seq(
 // Required by specs2 to get scalaz-stream
 resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 
-addSbtWeb("1.2.1")
+addSbtWeb("1.2.3")
 

--- a/src/main/scala/com/typesafe/sbt/jse/SbtJsTask.scala
+++ b/src/main/scala/com/typesafe/sbt/jse/SbtJsTask.scala
@@ -62,18 +62,23 @@ object SbtJsTask extends AutoPlugin {
     resourceManaged := target.value / moduleName.value
   )
 
-  val jsTaskSpecificUnscopedSettings =
+  val jsTaskSpecificUnscopedProjectSettings =
     inConfig(Assets)(jsTaskSpecificUnscopedConfigSettings) ++
-      inConfig(TestAssets)(jsTaskSpecificUnscopedConfigSettings) ++
-      Seq(
-        shellSource := {
-          SbtWeb.copyResourceTo(
-            (target in Plugin).value / moduleName.value,
-            shellFile.value,
-            streams.value.cacheDirectory / "copy-resource"
-          )
-        }
-      )
+      inConfig(TestAssets)(jsTaskSpecificUnscopedConfigSettings)
+
+  val jsTaskSpecificUnscopedBuildSettings: Seq[Setting[_]] =
+    Seq(
+      shellSource := {
+        SbtWeb.copyResourceTo(
+          (target in Plugin).value / moduleName.value,
+          shellFile.value,
+          streams.value.cacheDirectory / "copy-resource"
+        )
+      }
+    )
+
+  @deprecated("Add jsTaskSpecificUnscopedProjectSettings to AutoPlugin.projectSettings and jsTaskSpecificUnscopedBuildSettings to AutoPlugin.buildSettings", "1.2.0")
+  val jsTaskSpecificUnscopedSettings = jsTaskSpecificUnscopedProjectSettings ++ jsTaskSpecificUnscopedBuildSettings
 
   override def projectSettings = Seq(
     jsOptions := "{}",

--- a/src/sbt-test/sbt-js-engine/jstask/project/SbtHelloJsTask.scala
+++ b/src/sbt-test/sbt-js-engine/jstask/project/SbtHelloJsTask.scala
@@ -43,18 +43,22 @@ object SbtHelloJsTask extends AutoPlugin {
     ).toString()
   )
 
+  override def buildSettings = inTask(hello)(
+    SbtJsTask.jsTaskSpecificUnscopedBuildSettings ++ Seq(
+      moduleName := "hello",
+      shellFile := SbtHelloJsTask.getClass.getClassLoader.getResource("hello-shell.js")
+    )
+  )
+
   override def projectSettings = Seq(
     compress := false,
     fail := false
   ) ++
     inTask(hello)(
-      SbtJsTask.jsTaskSpecificUnscopedSettings ++
+      SbtJsTask.jsTaskSpecificUnscopedProjectSettings ++
         inConfig(Assets)(helloJsTaskUnscopedSettings) ++
         inConfig(TestAssets)(helloJsTaskUnscopedSettings) ++
         Seq(
-          moduleName := "hello",
-          shellFile := SbtHelloJsTask.getClass.getClassLoader.getResource("hello-shell.js"),
-
           taskMessage in Assets := "Saying hello",
           taskMessage in TestAssets := "Saying hello test"
 


### PR DESCRIPTION
This ensures there's only one task executed per build to extract it, not one task per project, so in multi project builds its not extracted multiple times.

See https://github.com/sbt/sbt-web/issues/130 for more details.