### PR TITLE
don't needlessly canonicalize paths

### DIFF
--- a/src/main/scala/com/typesafe/sbt/jse/SbtJsTask.scala
+++ b/src/main/scala/com/typesafe/sbt/jse/SbtJsTask.scala
@@ -283,7 +283,7 @@ object SbtJsTask extends AutoPlugin {
       LocalEngine.nodePathEnv(nodeModulePaths.to[immutable.Seq])
     )
 
-    val sources = ((Keys.sources in task in config).value ** ((includeFilter in task in config).value -- (excludeFilter in task in config).value)).get
+    val sources = ((Keys.sources in task in config).value ** ((includeFilter in task in config).value -- (excludeFilter in task in config).value)).get.map(f => new File(f.getCanonicalPath))
 
     val logger: Logger = state.value.log
 


### PR DESCRIPTION
This leads to bugs when users specify relative
paths in their .sbt files.

Fixes this issue:
https://github.com/sbt/sbt-jshint/issues/33