### PR TITLE
Adding plugin enabling documentation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ type can optionally produce managed resources.
 The other types of plugin are ones that wish to just invoke the js engine and so there are helper functions to do
 that.
 
+Enable this plugin in your project by adding it to your project's `plugins.sbt` file:
+
+    addSbtPlugin("com.typesafe.sbt" % "sbt-js-engine" % "1.1.4")
+
 The following options are provided:
 
 Option              | Description


### PR DESCRIPTION
Hiya,

I often find myself trying to remember the specific copypasta to enable this plugin.

I thought it might be useful to add it right to the reamde file for easy access!
