### PR TITLE
Make test reliable on case-insensitive filesystems

### DIFF
--- a/src/test/scala/com/typesafe/sbt/jse/gens.scala
+++ b/src/test/scala/com/typesafe/sbt/jse/gens.scala
@@ -29,7 +29,7 @@ object gens {
     for {
       depth <- choose(0, 20)
       directories <- listOfN(depth, directoryNameGen)
-    } yield new File(directories.mkString(File.separator, File.separator, ""))
+    } yield new File(directories.mkString(File.separator, File.separator, "")).getCanonicalFile
 
   val opResultGen: Gen[OpResult] = oneOf(const(OpFailure), resultOf(OpSuccess.apply _))
 


### PR DESCRIPTION
I was getting intermittent test failures on my Mac. These occurred when the test code generated a file path that corresponded to a real file path on my Mac, but where the case differed. When this happens the tests fail because the original file path changes when it's written to JSON due to a call of `getAbsolutePath` during the write operation.

For example, input of

```
/P/nrcgcxuHcvewmonfrsivAyxnv8svauhnCow/ueidnnUbpyrmtwlikdl/kotirVlrwVwnfavl/wplpWyms3fyzkfwgsruffiztBxemFysNhq9mnm7/trpJrxz/czziyvbexuslv3zrtnb1/JucnklvzFtjHTRe/imtsYperxfpaocl0gfxh1p0nm7y/JhycjzcqjrXmfx/mbmeyamcdOakwkx4Ouwmcj1eefyXoKg/jwqtYlIVnzsa/2rkf0oycj3g5zv8KzhixyosdhLe/ncbh98r/aikoqpeBJbzy6uKqqwMiCvm3kzqsa/Khffnukwbij/c5ozzzsqmk2qnrvq/ncecthsma6fjwyLjf25hbchyjrpkyjlsxm7e/fmeogug0nZo4Sqtotgizm8atwl2Ytfhc,
```

changes to

```
/p/nrcgcxuHcvewmonfrsivAyxnv8svauhnCow/ueidnnUbpyrmtwlikdl/kotirVlrwVwnfavl/wplpWyms3fyzkfwgsruffiztBxemFysNhq9mnm7/trpJrxz/czziyvbexuslv3zrtnb1/JucnklvzFtjHTRe/imtsYperxfpaocl0gfxh1p0nm7y/JhycjzcqjrXmfx/mbmeyamcdOakwkx4Ouwmcj1eefyXoKg/jwqtYlIVnzsa/2rkf0oycj3g5zv8KzhixyosdhLe/ncbh98r/aikoqpeBJbzy6uKqqwMiCvm3kzqsa/Khffnukwbij/c5ozzzsqmk2qnrvq/ncecthsma6fjwyLjf25hbchyjrpkyjlsxm7e/fmeogug0nZo4Sqtotgizm8atwl2Ytfhc,
```

after it has been written to JSON. This is because I have a directory called `/p` on my Mac. The same sort of bug could occur on other systems if `..` is generated in the path.