### PR TITLE
updated sbtWeb to 1.4.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,4 +10,4 @@ libraryDependencies ++= Seq(
   "junit" % "junit" % "4.12" % "test"
 )
 
-addSbtWeb("1.4.2")
+addSbtWeb("1.4.3")


### PR DESCRIPTION
This resolves an issue when reporting LineBasedProblem under sbt 1.0.

example: 
[Error] com.typesafe.sbt.web.LinePosition@7bc2d3ea: Missing semicolon.
instead of:
/home/patrik/Documents/github/sbt-eslint/sbt-eslint-plugin-tester/src/main/assets/some.js:2:14: Missing semicolon.
