### PR TITLE
Fix TriremeSpec

### DIFF
--- a/src/test/scala/com/typesafe/sbt/jse/engines/TriremeSpec.scala
+++ b/src/test/scala/com/typesafe/sbt/jse/engines/TriremeSpec.scala
@@ -6,6 +6,8 @@ import scala.collection.immutable
 
 class TriremeSpec extends Specification {
 
+  sequential
+
   "The Trireme engine" should {
     "execute some javascript by passing in a string arg and comparing its return value" in {
       val f = new File(classOf[TriremeSpec].getResource("test-node.js").toURI)


### PR DESCRIPTION
Tests need to run sequential otherwise the thread leak tests fails. It assumes other tests currently don't run in parallel.
See 

* https://github.com/typesafehub/js-engine/blob/4368c897573f876c4ef258bff5c3a54bb5febf73/src/test/scala/com/typesafe/jse/TriremeSpec.scala#L68-L69
* https://github.com/typesafehub/js-engine/blob/4368c897573f876c4ef258bff5c3a54bb5febf73/src/test/scala/com/typesafe/jse/TriremeSpec.scala#L16