### PR TITLE
Update sbt, start to add 2.0 evaluation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,9 +18,9 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 17, 11, 8
-      scala: 2.12.19
+      scala: 2.12.19, 3.7.2
       cmd: |
-        sbt ++$MATRIX_SCALA test ^scripted
+        sbt ++$MATRIX_SCALA test scripted
 
   finish:
     name: Finish

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,9 +18,9 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 17, 11, 8
-      scala: 2.12.19, 3.7.2
+      scala: 2.12.19
       cmd: |
-        sbt ++$MATRIX_SCALA test scripted
+        sbt ++$MATRIX_SCALA test ^scripted
 
   finish:
     name: Finish

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
       java: 17, 11, 8
       scala: 2.12.19
       cmd: |
-        sbt ++$MATRIX_SCALA test ^scripted
+        sbt ++$MATRIX_SCALA test scripted
 
   finish:
     name: Finish

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
 
 (pluginCrossBuild / sbtVersion) := {
   scalaBinaryVersion.value match {
-    case scala212 => "1.10.2"
-    case _        => "2.0.0-RC2"
+    case "2.12" => "1.10.2"
+    case _      => "2.0.0-RC2"
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,12 @@ lazy val `sbt-js-engine` = project in file(".")
 
 enablePlugins(SbtWebBase)
 
+lazy val scala212 = "2.12.20"
+lazy val scala3 = "3.3.4"
+ThisBuild / crossScalaVersions := Seq(scala212)
+
+sonatypeProfileName := "com.github.sbt.sbt-js-engine" // See https://issues.sonatype.org/browse/OSSRH-77819#comment-1203625
+
 description := "sbt js engine plugin"
 
 developers += Developer(
@@ -38,4 +44,11 @@ ThisBuild / dynverVTagPrefix := false
 Global / onLoad := (Global / onLoad).value.andThen { s =>
   dynverAssertTagVersion.value
   s
+}
+
+(pluginCrossBuild / sbtVersion) := {
+  scalaBinaryVersion.value match {
+    case scala212 => "1.10.2"
+    case _      => "2.0.0-M2"
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,11 @@ libraryDependencies ++= Seq(
   "org.webjars" % "webjars-locator-core" % "0.59",
 
   // Test deps
-  "junit" % "junit" % "4.13.2" % "test"
+  "junit" % "junit" % "4.13.2" % "test",
+
+  // Cross build compatibility
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.13.0"
+
 )
 
 addSbtWeb("1.6.0-M1")
@@ -50,5 +54,12 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
   scalaBinaryVersion.value match {
     case "2.12" => "1.10.2"
     case _      => "2.0.0-RC2"
+  }
+}
+
+scalacOptions := {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, major)) => Seq("-Xsource:3")
+    case _                => Seq.empty
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ lazy val `sbt-js-engine` = project in file(".")
 enablePlugins(SbtWebBase)
 
 lazy val scala212 = "2.12.20"
-lazy val scala3 = "3.3.4"
-ThisBuild / crossScalaVersions := Seq(scala212)
+lazy val scala3 = "3.7.2"
+ThisBuild / crossScalaVersions := Seq(scala212, scala3)
 
 sonatypeProfileName := "com.github.sbt.sbt-js-engine" // See https://issues.sonatype.org/browse/OSSRH-77819#comment-1203625
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,6 @@ lazy val scala212 = "2.12.20"
 lazy val scala3 = "3.7.2"
 ThisBuild / crossScalaVersions := Seq(scala212, scala3)
 
-sonatypeProfileName := "com.github.sbt.sbt-js-engine" // See https://issues.sonatype.org/browse/OSSRH-77819#comment-1203625
-
 description := "sbt js engine plugin"
 
 developers += Developer(

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
   "junit" % "junit" % "4.13.2" % "test"
 )
 
-addSbtWeb("1.5.8")
+addSbtWeb("1.6.0-M1")
 
 // Customise sbt-dynver's behaviour to make it work with tags which aren't v-prefixed
 ThisBuild / dynverVTagPrefix := false
@@ -49,6 +49,6 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
 (pluginCrossBuild / sbtVersion) := {
   scalaBinaryVersion.value match {
     case scala212 => "1.10.2"
-    case _      => "2.0.0-M2"
+    case _        => "2.0.0-RC2"
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.1
+sbt.version=1.11.4


### PR DESCRIPTION
Towards #139.

* Updates sbt to 1.11.4, adding 2.0.0-M2 awareness
* Sets up some variables for crossbuilds/evaluation.
* Removes `^` from `scripted` run to avoid a dep cycle.
* Adds Scala3 syntax to `2.12` mode, so we can start to resolve syntax issues.
* Updates to `sbt-web` `1.6.0-M1` to enable crossbuild later.

Stacks on top of #146 