### PR TITLE
Fix test failures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,8 @@ developers += Developer(
 )
 
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core" % "4.10.3" % "test",
-  "org.specs2" %% "specs2-scalacheck" % "4.10.3" % "test",
+  "org.specs2" %% "specs2-core" % "4.21.0" % "test",
+  "org.specs2" %% "specs2-scalacheck" % "4.21.0" % "test",
   "io.spray" %% "spray-json" % "1.3.6",
 
   // Trireme

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "version": "1.0.0",
     "dependencies": {
         "amdefine": "^1.0.1",
-        "grpc": "^1.24.11"
+        "@grpc/grpc-js": "^1.13.4"
     }
 }

--- a/src/test/scala/com/typesafe/sbt/jse/SbtJsTaskPluginSpec.scala
+++ b/src/test/scala/com/typesafe/sbt/jse/SbtJsTaskPluginSpec.scala
@@ -37,30 +37,33 @@ class SbtJsTaskPluginSpec extends Specification with ScalaCheck {
           }
       """)
 
-      import SbtJsTask.JsTaskProtocol._
+      import SbtJsTask.JsTaskProtocol.*
       val problemResultsPair = p.convertTo[ProblemResultsPair]
       problemResultsPair.problems.size must_== 1
-      problemResultsPair.problems(0).position().offset().get() must_== 5
-      problemResultsPair.problems(0).position().lineContent() must_== "a = 1"
-      problemResultsPair.problems(0).position().line().get() must_== 1
-      problemResultsPair.problems(0).message must_== "Missing semicolon."
-      problemResultsPair.problems(0).severity must_== Severity.Error
-      problemResultsPair.problems(0).position().sourceFile().get must_== new File("src/main/assets/js/a.js")
+      problemResultsPair.problems.head.position().offset().get() must_== 5
+      problemResultsPair.problems.head.position().lineContent() must_== "a = 1"
+      problemResultsPair.problems.head.position().line().get() must_== 1
+      problemResultsPair.problems.head.message must_== "Missing semicolon."
+      problemResultsPair.problems.head.severity must_== Severity.Error
+      problemResultsPair.problems.head.position().sourceFile().get must_== new File("src/main/assets/js/a.js")
       problemResultsPair.results.size must_== 1
-      val opSuccess = problemResultsPair.results(0).result.asInstanceOf[OpSuccess]
+      val opSuccess = problemResultsPair.results.head.result.asInstanceOf[OpSuccess]
       opSuccess.filesRead.size must_== 1
       opSuccess.filesWritten.size must_== 0
-      problemResultsPair.results(0).source must_== new File("src/main/assets/js/a.js")
+      problemResultsPair.results.head.source must_== new File("src/main/assets/js/a.js")
     }
 
     "Write a ProblemResultsPair as json then read it and recover the original value" in {
       import SbtJsTask.JsTaskProtocol.{ProblemResultsPair, problemResultPairFormat}
-      import gens._
-      import helpers._
+      import gens.*
+      import helpers.*
+
 
       prop { (doc: ProblemResultsPair) =>
         val roundTrip = problemResultPairFormat.read(problemResultPairFormat.write(doc))
-        roundTrip must beTypedEqualTo(doc)
+
+        roundTrip.results must containTheSameElementsAs(doc.results, sourceResultPairEquality)
+        roundTrip.problems must containTheSameElementsAs(doc.problems, lineBasedProblemEquality)
       }
     }
   }

--- a/src/test/scala/com/typesafe/sbt/jse/helpers.scala
+++ b/src/test/scala/com/typesafe/sbt/jse/helpers.scala
@@ -1,36 +1,23 @@
 package com.typesafe.sbt.jse
 
-import com.typesafe.sbt.jse.SbtJsTask.JsTaskProtocol.ProblemResultsPair
+import com.typesafe.sbt.jse.SbtJsTask.JsTaskProtocol.{ProblemResultsPair, SourceResultPair}
 import com.typesafe.sbt.web.LineBasedProblem
-import org.specs2.matcher.describe._
-
 
 object helpers {
 
-  implicit val problemResultsPairDiffable: Diffable[ProblemResultsPair] = new Diffable[ProblemResultsPair] {
-    override def diff(actual: ProblemResultsPair, expected: ProblemResultsPair): ComparisonResult = {
-      if (areEqualProblemResultsPairs(actual, expected)) {
-        OtherIdentical(actual)
-      } else {
-        new DifferentComparisonResult {
-          def render: String = stringifyProblemResultsPair(actual) + " != " + stringifyProblemResultsPair(expected)
-        }
-      }
-
-    }
-  }
-
-  private def areEqualLineBasedProblems(p1: LineBasedProblem, p2: LineBasedProblem): Boolean =
+  // Define a custom equality function for LineBasedProblem
+  def lineBasedProblemEquality(p1: LineBasedProblem, p2: LineBasedProblem): Boolean =
     p1.message == p2.message &&
-    p1.severity == p2.severity &&
-    p1.position.line.get == p2.position.line.get &&
-    p1.position.lineContent == p2.position.lineContent &&
-    p1.position.offset.get == p2.position.offset.get &&
-    p1.position.sourceFile.get == p2.position.sourceFile.get
+      p1.severity == p2.severity &&
+      p1.position.line == p2.position.line &&
+      p1.position.lineContent == p2.position.lineContent &&
+      p1.position.offset == p2.position.offset &&
+      p1.position.sourceFile.get.getCanonicalPath == p2.position.sourceFile.get.getCanonicalPath
 
-  private def areEqualProblemResultsPairs(p1: ProblemResultsPair, p2: ProblemResultsPair): Boolean =
-    p1.results == p2.results &&
-    p1.problems.zip(p2.problems).forall(x => areEqualLineBasedProblems(x._1, x._2))
+  // Define a custom equality function for SourceResultPair
+  def sourceResultPairEquality(p1: SourceResultPair, p2: SourceResultPair): Boolean =
+    p1.result == p2.result &&
+      p1.source.getCanonicalPath == p2.source.getCanonicalPath
 
   private def stringifyLineBasedProblem(p: LineBasedProblem): String =
     s"""|LineBasedProblem(
@@ -45,6 +32,6 @@ object helpers {
   private def stringifyProblemResultsPair(p: ProblemResultsPair): String =
     s"""|ProblemResultsPair(
         |  ${p.results}
-        |  ${p.problems.map(stringifyLineBasedProblem _)}
+        |  ${p.problems.map(stringifyLineBasedProblem)}
         |)""".stripMargin
 }

--- a/src/test/scala/com/typesafe/sbt/jse/helpers.scala
+++ b/src/test/scala/com/typesafe/sbt/jse/helpers.scala
@@ -8,16 +8,16 @@ object helpers {
   // Define a custom equality function for LineBasedProblem
   def lineBasedProblemEquality(p1: LineBasedProblem, p2: LineBasedProblem): Boolean =
     p1.message == p2.message &&
-      p1.severity == p2.severity &&
-      p1.position.line == p2.position.line &&
-      p1.position.lineContent == p2.position.lineContent &&
-      p1.position.offset == p2.position.offset &&
-      p1.position.sourceFile.get.getCanonicalPath == p2.position.sourceFile.get.getCanonicalPath
+    p1.severity == p2.severity &&
+    p1.position.line == p2.position.line &&
+    p1.position.lineContent == p2.position.lineContent &&
+    p1.position.offset == p2.position.offset &&
+    p1.position.sourceFile.get.getCanonicalPath == p2.position.sourceFile.get.getCanonicalPath
 
   // Define a custom equality function for SourceResultPair
   def sourceResultPairEquality(p1: SourceResultPair, p2: SourceResultPair): Boolean =
     p1.result == p2.result &&
-      p1.source.getCanonicalPath == p2.source.getCanonicalPath
+    p1.source.getCanonicalPath == p2.source.getCanonicalPath
 
   private def stringifyLineBasedProblem(p: LineBasedProblem): String =
     s"""|LineBasedProblem(

--- a/src/test/scala/com/typesafe/sbt/jse/npm/NpmSpec.scala
+++ b/src/test/scala/com/typesafe/sbt/jse/npm/NpmSpec.scala
@@ -34,6 +34,7 @@ class NpmSpec extends Specification {
       result.exitValue must_== 0
       stdErr must contain("npm http request GET https://registry.npmjs.org/amdefine") // when using webjar npm
         .or(contain("npm http fetch GET 200 https://registry.npmjs.org/amdefine")) // when using local installed npm
+        .or(contain("npm http cache https://registry.npmjs.org/amdefine")) // Just in case it's a cache hit
     }
   }
 }


### PR DESCRIPTION
* Update gRPC to a non-deprecated one. This resolves some warnings and failures that can occur locally.
* Update the stdErr checker in `NpmSpec` to also match cache hits, in case you have a cache hit.
* Upgrade to specs2 version that can crossbuild with Scala 2.12 and Scala3
* Fix an issue with SbtJsTaskPluginSpec. Specs2's `beTypedEqualTo` changed in `4.10.4` to _also_ do an `==` between the objects, which always fails due to `ProblemResultsPair` not being a case class. Switched to comparing objects with custom equality.
* Added a few fixes for Scala3 compatibility.